### PR TITLE
Chucking this in here seems to add the burger helper back in ?

### DIFF
--- a/client/src/components/Navbars/TopNavbar.js
+++ b/client/src/components/Navbars/TopNavbar.js
@@ -42,6 +42,18 @@ function TopNavbar({ isAuthenticated }) {
             <NavbarBrand to='/' tag={Link} id='navbar-brand'>
               Cashless
             </NavbarBrand>
+            <button
+              onClick={() => {
+                document.documentElement.classList.toggle("nav-open");
+                setCollapseOpen(!collapseOpen);
+              }}
+              aria-expanded={collapseOpen}
+              className="navbar-toggler"
+            >
+              <span className="navbar-toggler-bar top-bar"></span>
+              <span className="navbar-toggler-bar middle-bar"></span>
+              <span className="navbar-toggler-bar bottom-bar"></span>
+            </button>
           </div>
           <Collapse isOpen={collapseOpen} navbar>
             <Nav className='ml-auto' id='ceva' navbar>


### PR DESCRIPTION
This relates to Issue #21 - adding a burger helper. 

More would perhaps need to be done to add a 'x' to close as well as open the slideout. Adding this change anyway just to show how one would add the burger helper thingy to the menu. Very possibly this was already done by Sarah. 

Anyway not much needed to be done given that  things were already ready to be 'wired up' to the {collapseOpen} true/false toggle. So just copied some code from [now ui kit](https://github.com/CashlessSociety/creativetim/blob/f4644db8e3889d147510772e06dac400ec3ce165/now-ui-kit-pro-react-v1.4.0.zip/src/components/Navbars/DropdownFixedNavbar.js#L75) to get this. 